### PR TITLE
Bonfire.Me.Fake.fake_account!/1: fix the option name

### DIFF
--- a/lib/fake.ex
+++ b/lib/fake.ex
@@ -6,7 +6,7 @@ defmodule Bonfire.Me.Fake do
   # import Bonfire.Me.Integration
 
   def fake_account!(attrs \\ %{}) do
-    {:ok, account} = Accounts.signup(signup_form(attrs), must_confirm: false)
+    {:ok, account} = Accounts.signup(signup_form(attrs), must_confirm?: false)
     account
   end
 


### PR DESCRIPTION
Hi,

The option name `must_confirm` is incorrect according to https://github.com/bonfire-networks/bonfire_data_identity/blob/main/lib/email.ex#L109 , which prevents the function from creating fake accounts that are *verified*.  This PR fixes that.

Thanks,
srfsh